### PR TITLE
Use clamp-based grid widths for responsive layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -42,7 +42,7 @@ body{
 /* ==========================================================================
    2. LAYOUT & STRUCTURE
    ========================================================================== */
-.app-layout{display:grid; grid-template-columns:280px 1fr 320px; height:100vh; width:100vw;}
+.app-layout{display:grid; grid-template-columns:clamp(220px,25vw,280px) 1fr clamp(240px,25vw,320px); height:100vh; width:100vw;}
 .sidebar{
   background:var(--color-bg-secondary); border-right:1px solid var(--color-border-primary);
   display:flex; flex-direction:column; overflow-y:auto; padding:1rem; gap:1rem;
@@ -56,7 +56,7 @@ body{
   flex-grow:1; display:grid; grid-template-columns:repeat(auto-fill,minmax(180px,1fr));
   gap:1rem; padding:1rem; overflow-y:auto;
 }
-@media (max-width:1200px){.app-layout{grid-template-columns:260px 1fr}.sidebar-right{display:none}}
+@media (max-width:1200px){.app-layout{grid-template-columns:clamp(220px,25vw,280px) 1fr}.sidebar-right{display:none}}
 @media (max-width:768px){.app-layout{grid-template-columns:1fr}.sidebar-left{display:none}}
 
 /* ==========================================================================


### PR DESCRIPTION
## Summary
- Replace fixed sidebar widths with clamp-based values for responsiveness
- Update media queries to match new sidebar sizing

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b27be7ea188332b1928790e5d9f188