### PR TITLE
Adjust palette grid for small screens

### DIFF
--- a/style.css
+++ b/style.css
@@ -58,6 +58,7 @@ body{
 }
 @media (max-width:1200px){.app-layout{grid-template-columns:260px 1fr}.sidebar-right{display:none}}
 @media (max-width:768px){.app-layout{grid-template-columns:1fr}.sidebar-left{display:none}}
+@media (max-width:480px){.palette-container{grid-template-columns:repeat(auto-fill,minmax(120px,1fr));}}
 
 /* ==========================================================================
    3. CORE COMPONENTS


### PR DESCRIPTION
## Summary
- improve palette container layout on screens under 480px

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b27be34b388332a29701e051b1b3c6